### PR TITLE
feat(tmux): enable native macOS clipboard integration

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -3,11 +3,11 @@ unbind C-b
 set -g prefix C-q
 bind C-q send-prefix
 
-# Fix macOS clipboard + tmux issues
-# https://github.com/tmux/tmux/issues/543#issuecomment-248980734
-# https://github.com/ChrisJohnsen/tmux-MacOSX-pasteboard
+# Use login shell
 set -g default-shell $SHELL
-set -g default-command "reattach-to-user-namespace -l ${SHELL}"
+
+# Enable macOS clipboard integration
+set-option -g set-clipboard on
 
 # Enable true colour in tmux
 # https://news.ycombinator.com/item?id=37811248


### PR DESCRIPTION
## Summary
- remove obsolete `reattach-to-user-namespace` default command
- enable tmux's native macOS clipboard support

## Testing
- `tmux -f tmux/tmux.conf source-file tmux/tmux.conf` *(fails: command not found: tmux)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c149960ae883299f4accc8459eb8af